### PR TITLE
chore: removed redundant qualifiers

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: 1.65.0
+        toolchain: 1.76.0
         components: clippy
     - uses: actions/cache@v4
       continue-on-error: false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,3 @@
 [workspace]
 members = ["crates/*"]
+resolver = "2"

--- a/crates/subtale-mimir/src/query.rs
+++ b/crates/subtale-mimir/src/query.rs
@@ -40,14 +40,14 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Query<FactKey, FactType>
 where
-    FactKey: std::hash::Hash + std::cmp::Eq,
+    FactKey: std::hash::Hash + Eq,
 {
     /// The facts currently stored within the query (using an `IndexMap` as the
     /// data structure implementation).
     pub facts: IndexMap<FactKey, FactType>,
 }
 
-impl<FactKey: std::hash::Hash + std::cmp::Eq, FactType: std::marker::Copy>
+impl<FactKey: std::hash::Hash + Eq, FactType: Copy>
     Query<FactKey, FactType>
 {
     /// Instantiates a new instance of `Query` without allocating an underlying

--- a/crates/subtale-mimir/src/rule.rs
+++ b/crates/subtale-mimir/src/rule.rs
@@ -12,7 +12,7 @@ use crate::{evaluator::Evaluator, query::Query};
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Rule<FactKey, FactType, FactEvaluator: Evaluator<FactType>, Outcome>
 where
-    FactKey: std::hash::Hash + std::cmp::Eq,
+    FactKey: std::hash::Hash + Eq,
 {
     marker: PhantomData<FactType>,
     /// The map of facts and evaluators that will be used to evaluate each
@@ -24,9 +24,9 @@ where
 }
 
 impl<
-        FactKey: std::hash::Hash + std::cmp::Eq,
-        FactType: std::marker::Copy,
-        FactEvaluator: Evaluator<FactType> + std::marker::Copy,
+        FactKey: std::hash::Hash + Eq,
+        FactType: Copy,
+        FactEvaluator: Evaluator<FactType> + Copy,
         Outcome,
     > Rule<FactKey, FactType, FactEvaluator, Outcome>
 {

--- a/crates/subtale-mimir/src/ruleset.rs
+++ b/crates/subtale-mimir/src/ruleset.rs
@@ -23,15 +23,15 @@ use crate::{evaluator::Evaluator, query::Query, rule::Rule};
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Ruleset<FactKey, FactType, FactEvaluator: Evaluator<FactType>, Outcome>
 where
-    FactKey: std::hash::Hash + std::cmp::Eq,
+    FactKey: std::hash::Hash + Eq,
 {
     rules: Vec<Rule<FactKey, FactType, FactEvaluator, Outcome>>,
 }
 
 impl<
-        FactKey: std::hash::Hash + std::cmp::Eq,
-        FactType: std::marker::Copy,
-        FactEvaluator: Evaluator<FactType> + std::marker::Copy,
+        FactKey: std::hash::Hash + Eq,
+        FactType: Copy,
+        FactEvaluator: Evaluator<FactType> + Copy,
         Outcome,
     > Ruleset<FactKey, FactType, FactEvaluator, Outcome>
 {
@@ -65,7 +65,7 @@ impl<
         let mut matched = Vec::<&Rule<FactKey, FactType, FactEvaluator, Outcome>>::new();
 
         for rule in self.rules.iter() {
-            if matched.get(0).map_or(0, |x| x.evaluators.len()) <= rule.evaluators.len() {
+            if matched.first().map_or(0, |x| x.evaluators.len()) <= rule.evaluators.len() {
                 if rule.evaluate(query) {
                     matched.push(rule);
                 }


### PR DESCRIPTION
Removes redundant qualifiers identified by in-editor warnings in IntelliJ.
