### PR TITLE
refactor: removed redundant `cfg` blocks

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: 1.65.0
+        toolchain: 1.76.0
         components: clippy
     - uses: actions/cache@v4
       continue-on-error: false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,3 @@
 [workspace]
 members = ["crates/*"]
+resolver = "2"

--- a/crates/subtale-mimir/src/float.rs
+++ b/crates/subtale-mimir/src/float.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "float")]
 use float_cmp::approx_eq;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -8,7 +7,6 @@ use super::evaluator::Evaluator;
 /// Represents a bound of a range used during float comparisons made by
 /// `FloatEvaluator`.
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg(feature = "float")]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum FloatRangeBound {
     /// A bound that's exclusive of the contained value.
@@ -20,7 +18,6 @@ pub enum FloatRangeBound {
 /// A reference implementation of the `Evaluator` trait that allows for
 /// comparisons against facts with a value type of `f64`.
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg(feature = "float")]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum FloatEvaluator {
     /// Checks if a fact has a specific `f64` value (using the `float_cmp` crate
@@ -40,7 +37,6 @@ pub enum FloatEvaluator {
     InRange(FloatRangeBound, FloatRangeBound),
 }
 
-#[cfg(feature = "float")]
 impl Evaluator<f64> for FloatEvaluator {
     fn evaluate(self, value: f64) -> bool {
         match self {
@@ -72,7 +68,6 @@ impl Evaluator<f64> for FloatEvaluator {
     }
 }
 
-#[cfg(feature = "float")]
 impl FloatEvaluator {
     /// Utility function for composing an instance of `FloatEvaluator` that
     /// checks for values less than `value`.

--- a/crates/subtale-mimir/src/lib.rs
+++ b/crates/subtale-mimir/src/lib.rs
@@ -11,7 +11,7 @@
 //! FactType>`), where the key is the unique identifier of the fact, and the
 //! value is the fact's value.
 //!
-//! Also, your game will (most likey!) have predefined rules that define
+//! Also, your game will (most likely!) have predefined rules that define
 //! behaviour that should occur when one or more facts are true. We
 //! represent rules as a map (`Rule<FactKey, FactType, FactEvaluator,
 //! Outcome>`), where the key is the unique identifier of the fact, and the

--- a/crates/subtale-mimir/src/query.rs
+++ b/crates/subtale-mimir/src/query.rs
@@ -40,14 +40,14 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Query<FactKey, FactType>
 where
-    FactKey: std::hash::Hash + std::cmp::Eq,
+    FactKey: std::hash::Hash + Eq,
 {
     /// The facts currently stored within the query (using an `IndexMap` as the
     /// data structure implementation).
     pub facts: IndexMap<FactKey, FactType>,
 }
 
-impl<FactKey: std::hash::Hash + std::cmp::Eq, FactType: std::marker::Copy>
+impl<FactKey: std::hash::Hash + Eq, FactType: Copy>
     Query<FactKey, FactType>
 {
     /// Instantiates a new instance of `Query` without allocating an underlying

--- a/crates/subtale-mimir/src/rule.rs
+++ b/crates/subtale-mimir/src/rule.rs
@@ -12,7 +12,7 @@ use crate::{evaluator::Evaluator, query::Query};
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Rule<FactKey, FactType, FactEvaluator: Evaluator<FactType>, Outcome>
 where
-    FactKey: std::hash::Hash + std::cmp::Eq,
+    FactKey: std::hash::Hash + Eq,
 {
     marker: PhantomData<FactType>,
     /// The map of facts and evaluators that will be used to evaluate each
@@ -24,9 +24,9 @@ where
 }
 
 impl<
-        FactKey: std::hash::Hash + std::cmp::Eq,
-        FactType: std::marker::Copy,
-        FactEvaluator: Evaluator<FactType> + std::marker::Copy,
+        FactKey: std::hash::Hash + Eq,
+        FactType: Copy,
+        FactEvaluator: Evaluator<FactType> + Copy,
         Outcome,
     > Rule<FactKey, FactType, FactEvaluator, Outcome>
 {

--- a/crates/subtale-mimir/src/ruleset.rs
+++ b/crates/subtale-mimir/src/ruleset.rs
@@ -23,15 +23,15 @@ use crate::{evaluator::Evaluator, query::Query, rule::Rule};
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Ruleset<FactKey, FactType, FactEvaluator: Evaluator<FactType>, Outcome>
 where
-    FactKey: std::hash::Hash + std::cmp::Eq,
+    FactKey: std::hash::Hash + Eq,
 {
     rules: Vec<Rule<FactKey, FactType, FactEvaluator, Outcome>>,
 }
 
 impl<
-        FactKey: std::hash::Hash + std::cmp::Eq,
-        FactType: std::marker::Copy,
-        FactEvaluator: Evaluator<FactType> + std::marker::Copy,
+        FactKey: std::hash::Hash + Eq,
+        FactType: Copy,
+        FactEvaluator: Evaluator<FactType> + Copy,
         Outcome,
     > Ruleset<FactKey, FactType, FactEvaluator, Outcome>
 {
@@ -65,7 +65,7 @@ impl<
         let mut matched = Vec::<&Rule<FactKey, FactType, FactEvaluator, Outcome>>::new();
 
         for rule in self.rules.iter() {
-            if matched.get(0).map_or(0, |x| x.evaluators.len()) <= rule.evaluators.len() {
+            if matched.first().map_or(0, |x| x.evaluators.len()) <= rule.evaluators.len() {
                 if rule.evaluate(query) {
                     matched.push(rule);
                 }


### PR DESCRIPTION
The `#[cfg(feature = "float")]` statements in the `float.rs` module were redundant because the entire `pub mod float;` statement in `lib.rs` is already gated behind the `float` feature flag.